### PR TITLE
Add memory barrier to our implementation of memzero (taken from BoringSSL)

### DIFF
--- a/src/memzero.c
+++ b/src/memzero.c
@@ -64,5 +64,21 @@ void memzero(void *const pnt, const size_t len) {
   while (i < len) {
     pnt_[i++] = 0U;
   }
+
+  /* Memory barrier that scares the compiler away from optimizing out
+   * the above loop.
+   *
+   * Quoting Adam Langley <agl@google.com> in commit
+   * ad1907fe73334d6c696c8539646c21b11178f20f of BoringSSL (ISC License):
+   *
+   *    As best as we can tell, this is sufficient to break any optimisations
+   *    that might try to eliminate "superfluous" memsets.  This method is used
+   *    in memzero_explicit() the Linux kernel, too.  Its advantage is that it
+   *    is pretty efficient because the compiler can still implement the
+   *    memset() efficiently, just not remove it entirely.  See "Dead Store
+   *    Elimination (Still) Considered Harmful" by Yang et al. (USENIX Security
+   *    2017) for more background.
+   */
+  __asm__ __volatile__("" : : "r"(pnt_) : "memory");
 #endif
 }


### PR DESCRIPTION
Wiping memory that is about to be freed is a difficult challenge with optimizing compilers that might try to get rid of the "superfluous" memzero(). Our implementation of memzero() is taken from libsodium and tries to scare the compiler away from optimizing away the memory-clearing loop by using volatile pointers. This should work, but another approach entirely is to use (architecture portable!) assembly intrinsics to issue memory barrier, which forces the compiler to make sure the previous memory setting loop is completed before it concerns itself with anything that might come after, like deallocation.

This second approach is used in Linux kernel, Google's BoringSSL, and Bitcoin Core to force the compiler to back off.  Both approaches are complementary; this additional code gives us strictly greater assurance that the memory wipe is actually performed.

Note that this particular fix was originally copied from BoringSSL, which was released by Google under the ISC license, which is compatible with bc-crypto-base's BSD license.